### PR TITLE
:technologist: Improve usability of conan and cmake

### DIFF
--- a/drive/CMakeLists.txt
+++ b/drive/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "Default to Debug Build")
+endif(NOT DEFINED CMAKE_BUILD_TYPE)
+
+set(CMAKE_TOOLCHAIN_FILE conan_toolchain.cmake)
+
 project(demos VERSION 0.0.1 LANGUAGES CXX)
 
 find_package(libhal-lpc40xx REQUIRED CONFIG)


### PR DESCRIPTION
Rather than running:

```
conan install .. -s build_type=Debug --build=missing
cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
```

You can now simply run:

```
conan install ..
cmake ..
```

So long as this was run during setup:

```
conan profile update settings.build_type=Debug default
```

If the above command was not run to set the default build type to "Debug" call it now in order to set it. This way you will no longer need to use it in the conan command.

`--build=missing` will be removed soon as the
`gnu-arm-embedded-toolchain` is upgraded to override build settings and always build on its own.