### PR TITLE
:sparkles: Added ESP to science control loop

### DIFF
--- a/code/applications/control_loops/arm.cpp
+++ b/code/applications/control_loops/arm.cpp
@@ -24,7 +24,7 @@ hal::status application(sjsu::hardware_map& p_map)
 
   auto& esp = *p_map.esp;
   auto& terminal = *p_map.terminal;
-  auto& counter = *p_map.steady_clock;
+  auto& clock = *p_map.steady_clock;
   auto& can = *p_map.can;
   auto& i2c = *p_map.i2c;
 
@@ -36,19 +36,17 @@ hal::status application(sjsu::hardware_map& p_map)
     esp,
     "SJSU Robotics 2.4GHz",
     "R0Bot1cs3250",
-    hal::create_timeout(counter, 10s).value());
+    hal::create_timeout(clock, 10s).value()); 
 
-  while (true) {
+  while (!wifi_result) {
     wifi_result = hal::esp8266::at::wlan_client::create(
       esp,
       "SJSU Robotics 2.4GHz",
       "R0Bot1cs3250",
-      hal::create_timeout(counter, 10s).value());
-
-    if (wifi_result) {
-      break;
-    }
-    HAL_CHECK(hal::write(terminal, "failed to connect to wifi"));
+      hal::create_timeout(clock, 10s).value());
+      if (!wifi_result) {
+        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi"));
+      }
   }
   HAL_CHECK(hal::write(terminal, "ESP created!\n"));
 
@@ -56,12 +54,13 @@ hal::status application(sjsu::hardware_map& p_map)
 
   auto socket_result = hal::esp8266::at::socket::create(
     wifi,
-    HAL_CHECK(hal::create_timeout(counter, 1s)),
+    HAL_CHECK(hal::create_timeout(clock, 1s)), 
     {
       .type = hal::socket::type::tcp,
-      .domain = "192.168.1.110",
+      .domain = "13.56.207.97",
       .port = "5000",
     });
+    // this is for the web server hosted by nate: http://13.56.207.97:5000/arm
 
   if (!socket_result) {
     HAL_CHECK(hal::write(terminal, "TCP Socket couldn't be established\n"));
@@ -69,19 +68,20 @@ hal::status application(sjsu::hardware_map& p_map)
   }
 
   auto socket = std::move(socket_result.value());
+  HAL_CHECK(hal::write(terminal, "Server found"));
 
   auto can_router = hal::can_router::create(can).value();
 
   auto rotunda_motor =
-    HAL_CHECK(hal::rmd::drc::create(can_router, counter, 8.0, 0x141));
+    HAL_CHECK(hal::rmd::drc::create(can_router, clock, 8.0, 0x141));
   auto shoulder_motor =
-    HAL_CHECK(hal::rmd::drc::create(can_router, counter, 8 * 65 / 16, 0x142));
+    HAL_CHECK(hal::rmd::drc::create(can_router, clock, 8 * 65 / 16, 0x142));
   auto elbow_motor =
-    HAL_CHECK(hal::rmd::drc::create(can_router, counter, 8 * 5 / 2, 0x143));
+    HAL_CHECK(hal::rmd::drc::create(can_router, clock, 8 * 5 / 2, 0x143));
   auto left_wrist_motor =
-    HAL_CHECK(hal::rmd::drc::create(can_router, counter, 8.0, 0x144));
+    HAL_CHECK(hal::rmd::drc::create(can_router, clock, 8.0, 0x144));
   auto right_wrist_motor =
-    HAL_CHECK(hal::rmd::drc::create(can_router, counter, 8.0, 0x145));
+    HAL_CHECK(hal::rmd::drc::create(can_router, clock, 8.0, 0x145));
 
   auto pca9685 = HAL_CHECK(hal::pca::pca9685::create(i2c, 0b100'0000));
   auto pwm0 = pca9685.get_pwm_channel<0>();
@@ -99,7 +99,7 @@ hal::status application(sjsu::hardware_map& p_map)
   arm::motors_feedback feedback;
 
   HAL_CHECK(hal::write(terminal, "Starting control loop..."));
-  HAL_CHECK(hal::delay(counter, 1000ms));
+  HAL_CHECK(hal::delay(clock, 1000ms));
 
   while (true) {
     buffer.fill('.');
@@ -107,13 +107,13 @@ hal::status application(sjsu::hardware_map& p_map)
       "GET /arm?HB=0&IO=1 HTTP/1.1\r\n Host: 192.168.1.110:5000/\r\n\r\n";
 
     auto write_result = socket.write(
-      hal::as_bytes(get_request), hal::create_timeout(counter, 1000ms).value());
+      hal::as_bytes(get_request), hal::create_timeout(clock, 1000ms).value());
 
     if (!write_result) {
       HAL_CHECK(hal::write(terminal, "Failed:  \n"));
       continue;
     }
-    HAL_CHECK(hal::delay(counter, 100ms));
+    HAL_CHECK(hal::delay(clock, 100ms));
 
     auto received = HAL_CHECK(socket.read(buffer)).data;
     auto result = to_string_view(received);

--- a/code/applications/control_loops/arm.cpp
+++ b/code/applications/control_loops/arm.cpp
@@ -45,7 +45,7 @@ hal::status application(sjsu::hardware_map& p_map)
       "R0Bot1cs3250",
       hal::create_timeout(clock, 10s).value());
       if (!wifi_result) {
-        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi"));
+        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi\n"));
       }
   }
   HAL_CHECK(hal::write(terminal, "ESP created!\n"));
@@ -68,7 +68,7 @@ hal::status application(sjsu::hardware_map& p_map)
   }
 
   auto socket = std::move(socket_result.value());
-  HAL_CHECK(hal::write(terminal, "Server found"));
+  HAL_CHECK(hal::write(terminal, "Server found \n"));
 
   auto can_router = hal::can_router::create(can).value();
 

--- a/code/applications/control_loops/drive.cpp
+++ b/code/applications/control_loops/drive.cpp
@@ -54,7 +54,7 @@ hal::status application(sjsu::hardware_map& p_map)
       "R0Bot1cs3250",
       hal::create_timeout(clock, 10s).value());
       if (!wifi_result) {
-        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi"));
+        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi\n"));
       }
   }
   HAL_CHECK(hal::write(terminal, "ESP created!\n"));
@@ -77,7 +77,7 @@ hal::status application(sjsu::hardware_map& p_map)
   }
 
   auto socket = std::move(socket_result.value());
-  HAL_CHECK(hal::write(terminal, "Server found"));
+  HAL_CHECK(hal::write(terminal, "Server found\n"));
 
   auto can_router = hal::can_router::create(can).value();
 

--- a/code/applications/control_loops/drive.cpp
+++ b/code/applications/control_loops/drive.cpp
@@ -41,26 +41,36 @@ hal::status application(sjsu::hardware_map& p_map)
   static std::string_view get_request = "";
 
   HAL_CHECK(hal::write(terminal, "Starting program...\n"));
-
   auto wifi_result = hal::esp8266::at::wlan_client::create(
-    esp, "Corey", "0123456789", HAL_CHECK(hal::create_timeout(clock, 10s)));
+    esp,
+    "SJSU Robotics 2.4GHz",
+    "R0Bot1cs3250",
+    hal::create_timeout(clock, 10s).value()); 
 
-  if (!wifi_result) {
-    HAL_CHECK(hal::write(terminal, "Failed to create wifi client!\n"));
-    return wifi_result.error();
+  while (!wifi_result) {
+    wifi_result = hal::esp8266::at::wlan_client::create(
+      esp,
+      "SJSU Robotics 2.4GHz",
+      "R0Bot1cs3250",
+      hal::create_timeout(clock, 10s).value());
+      if (!wifi_result) {
+        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi"));
+      }
   }
+  HAL_CHECK(hal::write(terminal, "ESP created!\n"));
 
   auto wifi = wifi_result.value();
 
-  auto socket_result =
-    hal::esp8266::at::socket::create(wifi,
-                                     HAL_CHECK(hal::create_timeout(clock, 1s)),
-                                     {
-                                       .type = hal::socket::type::tcp,
-                                       .domain = "13.56.207.97",
-                                       .port = "5000",
-                                     });
-  // this is for the web server hosted by nate: http://13.56.207.97:5000/drive
+  auto socket_result = hal::esp8266::at::socket::create(
+    wifi,
+    HAL_CHECK(hal::create_timeout(clock, 1s)), 
+    {
+      .type = hal::socket::type::tcp,
+      .domain = "13.56.207.97",
+      .port = "5000",
+    });
+    // this is for the web server hosted by nate: http://13.56.207.97:5000/drive
+
   if (!socket_result) {
     HAL_CHECK(hal::write(terminal, "TCP Socket couldn't be established\n"));
     return socket_result.error();
@@ -68,6 +78,7 @@ hal::status application(sjsu::hardware_map& p_map)
 
   auto socket = std::move(socket_result.value());
   HAL_CHECK(hal::write(terminal, "Server found"));
+
   auto can_router = hal::can_router::create(can).value();
 
   auto left_steer_motor =
@@ -83,8 +94,7 @@ hal::status application(sjsu::hardware_map& p_map)
   auto right_hub_motor =
     HAL_CHECK(hal::rmd::drc::create(can_router, clock, 15.0, 0x144));
 
-  Drive::tri_wheel_router::leg right(
-    right_steer_motor, right_hub_motor, magnet0);
+  Drive::tri_wheel_router::leg right(right_steer_motor, right_hub_motor, magnet0);
   Drive::tri_wheel_router::leg left(left_steer_motor, left_hub_motor, magnet2);
   Drive::tri_wheel_router::leg back(back_steer_motor, back_hub_motor, magnet1);
 

--- a/code/applications/control_loops/science.cpp
+++ b/code/applications/control_loops/science.cpp
@@ -4,6 +4,9 @@
 #include "../../science/implementations/pressure_sensor_driver.hpp"
 #include "../../science/implementations/state_machine.hpp"
 
+#include <libhal-esp8266/at/socket.hpp>
+#include <libhal-esp8266/at/wlan_client.hpp>
+#include <libhal-esp8266/util.hpp>
 #include <libhal-pca/pca9685.hpp>
 #include <libhal/adc.hpp>
 #include <libhal/input_pin.hpp>
@@ -28,10 +31,53 @@ hal::status application(sjsu::hardware_map& p_map)
   auto pca_pwm_0 = pca9685.get_pwm_channel<0>();
   auto pca_pwm_1 = pca9685.get_pwm_channel<1>();
   auto pca_pwm_2 = pca9685.get_pwm_channel<2>();
-  auto& steady_clock = *p_map.steady_clock;
+  auto& clock = *p_map.steady_clock;
+  auto& esp = *p_map.esp;
 
   std::string response;
   int revolver_hall_value = 1;
+
+  std::array<hal::byte, 8192> buffer{};
+  static std::string_view get_request = "";
+
+  HAL_CHECK(hal::write(terminal, "Starting program...\n"));
+  auto wifi_result = hal::esp8266::at::wlan_client::create(
+    esp,
+    "SJSU Robotics 2.4GHz",
+    "R0Bot1cs3250",
+    hal::create_timeout(clock, 10s).value()); 
+
+  while (!wifi_result) {
+    wifi_result = hal::esp8266::at::wlan_client::create(
+      esp,
+      "SJSU Robotics 2.4GHz",
+      "R0Bot1cs3250",
+      hal::create_timeout(clock, 10s).value());
+      if (!wifi_result) {
+        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi"));
+      }
+  }
+  HAL_CHECK(hal::write(terminal, "ESP created!\n"));
+
+  auto wifi = wifi_result.value();
+
+  auto socket_result = hal::esp8266::at::socket::create(
+    wifi,
+    HAL_CHECK(hal::create_timeout(clock, 1s)), 
+    {
+      .type = hal::socket::type::tcp,
+      .domain = "13.56.207.97",
+      .port = "5000",
+    });
+    // this is for the web server hosted by nate: http://13.56.207.97:5000/science
+
+  if (!socket_result) {
+    HAL_CHECK(hal::write(terminal, "TCP Socket couldn't be established\n"));
+    return socket_result.error();
+  }
+
+  auto socket = std::move(socket_result.value());
+  HAL_CHECK(hal::write(terminal, "Server found"));
 
   // Constants
   static constexpr float MIN_SEAL_DUTY_CYCLE = 0.065f;
@@ -43,27 +89,27 @@ hal::status application(sjsu::hardware_map& p_map)
   science::pressure_sensor pressure(pressure_adc);
   science::mq4_methane_sensor methane(methane_adc);
   // auto carbon_dioxide = HAL_CHECK(science::Co2Sensor::create(*p_map.i2c,
-  // steady_clock));
+  // clock));
   science::state_machine state_machine;
 
   science::science_commands mc_commands;
   science::science_data mc_data;
 
   HAL_CHECK(revolver_spinner.frequency(50.0_Hz));
-  HAL_CHECK(hal::delay(steady_clock, 10ms));
+  HAL_CHECK(hal::delay(clock, 10ms));
   HAL_CHECK(pca_pwm_0.frequency(1.50_kHz));
-  HAL_CHECK(hal::delay(steady_clock, 10ms));
+  HAL_CHECK(hal::delay(clock, 10ms));
   mc_commands.is_operational = 1;
 
   while (true) {
     // mc_commands = HAL_CHECK(mc_handler.ParseMissionControlData(response,
     // terminal));
     mc_data.pressure_level = HAL_CHECK(pressure.get_parsed_data());
-    HAL_CHECK(hal::delay(steady_clock, 5ms));
+    HAL_CHECK(hal::delay(clock, 5ms));
     mc_data.methane_level = HAL_CHECK(methane.get_parsed_data());
-    HAL_CHECK(hal::delay(steady_clock, 5ms));
+    HAL_CHECK(hal::delay(clock, 5ms));
     revolver_hall_value = HAL_CHECK(in_pin0.level()).state;
-    HAL_CHECK(hal::delay(steady_clock, 5ms));
+    HAL_CHECK(hal::delay(clock, 5ms));
     // mc_data.co2_level = HAL_CHECK(carbon_dioxide.read_co2());
     mc_data.pressure_level = 100;
 
@@ -75,62 +121,62 @@ hal::status application(sjsu::hardware_map& p_map)
     mc_commands.state_step = 1;
     if (mc_data.status.move_revolver_status == science::status::in_progress) {
       HAL_CHECK(revolver_spinner.duty_cycle(0.076f));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
     } else if (mc_data.status.move_revolver_status ==
                  science::status::complete &&
                mc_data.status.seal_status == science::status::not_started) {
       HAL_CHECK(revolver_spinner.duty_cycle(0.075f));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
     } else if (mc_data.status.seal_status == science::status::in_progress) {
       HAL_CHECK(seal_spinner.duty_cycle(MAX_SEAL_DUTY_CYCLE));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
     } else if (mc_data.status.depressurize_status ==
                science::status::in_progress) {
       // start vacuum pump. Assume 40v input. Step down to 12v.
       // 12/40 = 0.30
       HAL_CHECK(pca_pwm_0.duty_cycle(0.40f));  // 12/30
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
       mc_data.pressure_level = 0;
     } else if (mc_data.status.depressurize_status ==
                  science::status::complete &&
                mc_data.status.inject_status == science::status::not_started) {
       // stop vacuum pump
       HAL_CHECK(pca_pwm_0.duty_cycle(0.00f));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
     } else if (mc_data.status.inject_status == science::status::in_progress) {
       // start injecting dosing pumps. Assume 40v input. Step down to 6v.
       // 6/40 = 0.15
       HAL_CHECK(pca_pwm_1.duty_cycle(0.15f));
       HAL_CHECK(pca_pwm_2.duty_cycle(0.15f));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
-      HAL_CHECK(hal::delay(steady_clock, 5s));
+      HAL_CHECK(hal::delay(clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5s));
       mc_data.pressure_level = 100;
     } else if (mc_data.status.inject_status == science::status::complete) {
       // stop injecting dosing pumps
       HAL_CHECK(pca_pwm_1.duty_cycle(0.00f));
       HAL_CHECK(pca_pwm_2.duty_cycle(0.00f));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
       mc_commands.state_step = 2;
     } else if (mc_data.status.clear_status == science::status::in_progress) {
       // start vacuum pump. Assume 40v input. Step down to 12v.
       // 12/40 = 0.30
       HAL_CHECK(pca_pwm_0.duty_cycle(0.40f));  // 12/30
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
-      HAL_CHECK(hal::delay(steady_clock, 5s));
+      HAL_CHECK(hal::delay(clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5s));
       mc_data.pressure_level = 0;
     } else if (mc_data.status.clear_status == science::status::complete &&
                mc_data.status.unseal_status == science::status::not_started) {
       // stop vacuum pump
       HAL_CHECK(pca_pwm_0.duty_cycle(0.00f));
-      HAL_CHECK(hal::delay(steady_clock, 5ms));
+      HAL_CHECK(hal::delay(clock, 5ms));
     } else if (mc_data.status.unseal_status == science::status::in_progress) {
       HAL_CHECK(seal_spinner.duty_cycle(MIN_SEAL_DUTY_CYCLE));
-      HAL_CHECK(hal::delay(steady_clock, 2s));
+      HAL_CHECK(hal::delay(clock, 2s));
     }
     response = science::create_GET_request_parameter_with_rover_status(mc_data);
     mc_data.status.Print(terminal);
-    HAL_CHECK(hal::delay(steady_clock, 10ms));
+    HAL_CHECK(hal::delay(clock, 10ms));
   }
   return hal::success();
 }

--- a/code/applications/control_loops/science.cpp
+++ b/code/applications/control_loops/science.cpp
@@ -54,7 +54,7 @@ hal::status application(sjsu::hardware_map& p_map)
       "R0Bot1cs3250",
       hal::create_timeout(clock, 10s).value());
       if (!wifi_result) {
-        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi"));
+        HAL_CHECK(hal::write(terminal, "Failed to connect to wifi\n"));
       }
   }
   HAL_CHECK(hal::write(terminal, "ESP created!\n"));
@@ -77,7 +77,7 @@ hal::status application(sjsu::hardware_map& p_map)
   }
 
   auto socket = std::move(socket_result.value());
-  HAL_CHECK(hal::write(terminal, "Server found"));
+  HAL_CHECK(hal::write(terminal, "Server found\n"));
 
   // Constants
   static constexpr float MIN_SEAL_DUTY_CYCLE = 0.065f;


### PR DESCRIPTION
Resolves #79. Cleaned up the ESP portion of code in the arm and drive control loops to be consistent with each other. Also made sure they both retry to establish a connection if they fail initially, and then added this ESP code to the science control loop as well. Also standardized the variable names used throughout the three subsystems for better readability